### PR TITLE
Minor: removed unneccessary error checking

### DIFF
--- a/web-cache-vulnerability-scanner.go
+++ b/web-cache-vulnerability-scanner.go
@@ -541,10 +541,6 @@ func setProxy() *url.URL {
 		//caCertPool,err := x509.SystemCertPool()
 		// führt zu crypto/x509: system root pool is not available on Windows
 		caCertPool := x509.NewCertPool()
-		if err != nil {
-			msg := "Proxy: " + err.Error() + "\n"
-			pkg.PrintFatal(msg)
-		}
 		caCertPool.AppendCertsFromPEM(caCert)
 
 		tlsConfig := &tls.Config{RootCAs: caCertPool,


### PR DESCRIPTION
Hi,

This is just a minor PR. I removed the error checking here because there is no `err` value that is needed to be checked from the previous `NewCertPool` call.