### PR TITLE
Update install method

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Prebuilt binaries of WCVS are provided on the [releases page](https://github.com
 ## Option 2: Fetch Repository Using Go
 The repository can be fetched using Go.
 ```
-go get -u https://github.com/Hackmanit/Web-Cache-Vulnerability-Scanner
+go get -u github.com/Hackmanit/Web-Cache-Vulnerability-Scanner
 ```
 
 # Usage


### PR DESCRIPTION
"go get" don't accept the `https://` part.